### PR TITLE
Add image deployer script, refactor docs, various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,39 +16,29 @@ As for deployment, the plan is to run this in parallel with hammers v1, and incr
 
 # Current Hammers
 
+- [Periodic Node Inspector](docs/periodic_node_inspector.md)
+- [Floating IP (and router) Reaper](docs/ip_cleaner.md)
+- [Image Deployer](docs/image_deployer.md)
 
-## Periodic Node Inspector
+# Running Hammers
 
-Ensures ironic-inspector runs against all nodes every so often.
+Create a virtual environment and install the dependencies:
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install .
+```
 
-Since this loops over all ironic nodes and modifies the state, it will eventually integrate the following other hammer's functionality:
+Then you can reference the hammers directly:
+```
+$ image_deployer -h
+```
 
-1. resetting the state of ironic hosts from `error`, usually from neutron port timeouts, or ipmi failures
-1. cleaning nodes to set bios boot configuration, or updating firmware
-1. syncing metadata from referenceapi to blazar
-1. checking if the ironic inspection data is unexpectly bad, such as if a disk is missing
-1. other maintenance tasks that would require a "lock" on a given node (at least until we tell doni to take this over)
+Instally optional dependencies if desired:
+```
+pip install .[dev]
+```
 
-## Floating IP (and router) Reaper
+# To Dos
 
-CHI has two ways to get public IPs, reservable and ad-hoc.
-Although quotas limit how many ad-hoc IPs a project may allocate, nothing cleans them up automatically, even if not used.
-
-This script will delete floating IPs IFF:
-
-1. they are not a blazar reservable IP
-1. they are not of status `ACTIVE`
-1. `updated_at` is older than `--grace-days` days
-
-This script will additionally remove unused routers to free up their addresses, IFF:
-
-1. their public IP is not a blazar reservable IP
-1. they are not attached to any neutron networks (e.g. have only a public IP, but no allocated interfaces)
-1. `updated_at` is older than `--grace-days` days
-
-
-### Arguments
-
-- cloud: which entry in clouds.yaml to run against
-- dry-run: prints out what addresses would be deleted, instead of deleting them
-- grace-days: how long an address needs to be unused before we clean it up
+- Add tests for image deployer

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ image_deployer -h
 
 Instally optional dependencies if desired:
 ```
-pip install .[dev]
+pip install '.[dev]'
 ```
 
 # To Dos

--- a/config/site.yaml
+++ b/config/site.yaml
@@ -1,0 +1,8 @@
+---
+image_container: chameleon-supported-images
+image_type: qcow2
+image_prefix: testing_
+scope: prod
+image_store_cloud: uc_dev
+object_store_url:
+

--- a/docs/image_deployer.md
+++ b/docs/image_deployer.md
@@ -1,0 +1,48 @@
+# image_deployer.py
+
+The `image_deployer.py` script is a new (and in development) approach to
+downloading images from a central object store and pushing them to Glance
+at specific sites.
+
+The script requires a site.yaml file configured with the following
+settings:
+```
+---
+image_container: chameleon-supported-images
+image_type: qcow2
+image_prefix: testing_
+scope: prod
+image_store_cloud: uc_dev
+object_store_url: https://chi.uc.chameleoncloud.org:7480/swift/v1/{the account with the image container, e.g. AUTH_id}
+```
+
+The image container for production images is stored in a central
+object store and should use the scope `prod` by default.
+
+The image container name is `chameleon-supported-images`.
+
+Individual sites can select an `image_type` of `raw` or `qcow2`
+for the image format to deploy. All images should have both
+formats in the object store.
+
+The `image_prefix` will be added to images when they are initially
+pushed to Glance. After pushing the image, any images with an
+existing name will be archived with their build date and then
+the `image_prefix` will be removed from the newly pushed images.
+
+The `image_store_cloud` is the location of the site with Glance
+where the images should be pushed to. This should contain the
+credentials for your cloud in a `clouds.yaml` file for the
+OpenStack client.
+
+After installing the dependencies, you can run the tool as follows:
+```
+python3 site_tools/image_deployer.py --site-yaml ~/site.yaml
+```
+
+Additionally you can specify either `--dry-run` to see which images
+are available and need syncing or `--debug` if you run into issues
+and would like to see debug logging.
+
+This tool will likely be evolving in the near future as it is
+utilized for image deployment.

--- a/docs/image_deployer.md
+++ b/docs/image_deployer.md
@@ -37,7 +37,7 @@ OpenStack client.
 
 After installing the dependencies, you can run the tool as follows:
 ```
-python3 site_tools/image_deployer.py --site-yaml ~/site.yaml
+image_deployer --site-yaml ~/site.yaml
 ```
 
 Additionally you can specify either `--dry-run` to see which images

--- a/docs/ip_cleaner.md
+++ b/docs/ip_cleaner.md
@@ -1,0 +1,23 @@
+# Floating IP (and router) Reaper
+
+CHI has two ways to get public IPs, reservable and ad-hoc.
+Although quotas limit how many ad-hoc IPs a project may allocate, nothing cleans them up automatically, even if not used.
+
+This script will delete floating IPs IFF:
+
+1. they are not a blazar reservable IP
+1. they are not of status `ACTIVE`
+1. `updated_at` is older than `--grace-days` days
+
+This script will additionally remove unused routers to free up their addresses, IFF:
+
+1. their public IP is not a blazar reservable IP
+1. they are not attached to any neutron networks (e.g. have only a public IP, but no allocated interfaces)
+1. `updated_at` is older than `--grace-days` days
+
+
+## Arguments
+
+- cloud: which entry in clouds.yaml to run against
+- dry-run: prints out what addresses would be deleted, instead of deleting them
+- grace-days: how long an address needs to be unused before we clean it up

--- a/docs/periodic_node_inspector.md
+++ b/docs/periodic_node_inspector.md
@@ -1,0 +1,11 @@
+# Periodic Node Inspector
+
+Ensures ironic-inspector runs against all nodes every so often.
+
+Since this loops over all ironic nodes and modifies the state, it will eventually integrate the following other hammer's functionality:
+
+1. resetting the state of ironic hosts from `error`, usually from neutron port timeouts, or ipmi failures
+1. cleaning nodes to set bios boot configuration, or updating firmware
+1. syncing metadata from referenceapi to blazar
+1. checking if the ironic inspection data is unexpectly bad, such as if a disk is missing
+1. other maintenance tasks that would require a "lock" on a given node (at least until we tell doni to take this over)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "oslo.log",
   "iso8601",
   "pyyaml",
-  "openstacksdk>1.0.1",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
   "oslo.service",
   "oslo.log",
   "iso8601",
+  "pyyaml",
+  "openstacksdk>1.0.1",
 ]
 
 
@@ -40,3 +42,4 @@ dev = [
 periodic_inspector = "hammers.periodic_node_inspector:main"
 floating_ip_reaper = "hammers.ip_cleaner:launch_main"
 expired_project_reaper = "hammers.expired_project_cleaner:launch_main"
+image_deployer = "hammers.image_deployer:launch_main"

--- a/src/hammers/image_deployer.py
+++ b/src/hammers/image_deployer.py
@@ -1,0 +1,368 @@
+import argparse
+import datetime
+import json
+import logging
+import requests
+import sys
+import tempfile
+import yaml
+
+import openstack
+
+from itertools import islice
+
+
+class Image:
+    def __init__(self, name, type, base_container, scope, current_path):
+        self.name = name
+        self.manifest_name = name + ".manifest"
+        # sites only support 1 type so we will use the one the user selected: raw or qcow2
+        self.type = type
+        self.disk_name = name + "." + type
+        self.scope = scope
+        self.base_container = base_container
+        self.current_path = current_path
+        self.container_path = self.base_container + "/" + self.current_path
+
+    def __str__(self):
+        return f"Image(name={self.name})"
+
+
+def get_openstack_connection(cloud_name):
+    return openstack.connect(cloud=cloud_name)
+
+
+def get_current_value(storage_url, base_container, scope):
+    url = f"{storage_url}/{base_container}/{scope}/current"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise Exception(f"Error getting current value: {response.content}")
+    return json.loads(response.text.strip())
+
+
+def get_available_images(
+        storage_url,
+        base_container,
+        scope,
+        current_values,
+        image_type):
+    available_images = []
+
+    for image_name in current_values.keys():
+        current = current_values[image_name]
+        current_path = f"{scope}/versions/{current}"
+        url = f"{storage_url}/{base_container}/?prefix={current_path}"
+        logging.debug(f"Checking available images at {url}...")
+        response = requests.get(url)
+        if response.status_code != 200:
+            raise Exception("Error getting available images: " +
+                            f"{response.content}")
+
+        current_objects = response.text.splitlines()
+        logging.debug(f"Current objects: {current_objects}")
+        for object in islice(current_objects, 1, None):
+            object_name = object.split("/")[-1]
+            if object_name.endswith(image_name + ".manifest"):
+                name = object_name.rstrip(".manifest")
+                available_images.append(
+                    Image(name,
+                          image_type,
+                          base_container,
+                          scope,
+                          current_path)
+                )
+
+    return available_images
+
+
+def get_site_images(connection):
+    logging.debug("Checking public site images...")
+    images = [
+        i.name
+        for i in connection.image.images(
+            visibility="public"
+        )
+    ]
+    return images
+
+
+def should_sync_image(image_disk_name, site_images, current):
+    if image_disk_name in site_images:
+        logging.debug(f"Image {image_disk_name} already in site images.")
+        image = image_connection.image.find_image(image_disk_name)
+        image_properties = image.properties
+        logging.debug(f"Image properties: {image_properties}")
+        image_current_value = image_properties.get("current", None)
+        logging.debug(f"Image {image_disk_name} current value: {image_current_value}")
+        if image_current_value is not None and image_current_value == current:
+            logging.debug(f"Image {image_disk_name} is already current.")
+            return False
+    return True
+
+
+def download_object_to_file(storage_url, path, file_name):
+    url = f"{storage_url}/{path}/{file_name}"
+    response = requests.get(url, stream=True)
+
+    if response.status_code != 200:
+        raise Exception(f"Error downloading object {file_name}: {response.content}")
+
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        for chunk in response.iter_content(chunk_size=65536):
+            temp_file.write(chunk)
+            temp_file.flush()
+    logging.debug(f"Downloaded object to {temp_file.name}.")
+    return temp_file
+
+
+def upload_image_to_glance(image_connection,
+                           image_prefix,
+                           image_disk_name,
+                           image_file_name,
+                           disk_format,
+                           manifest_data):
+    image_prefix_name = image_prefix + image_disk_name
+
+    logging.debug(f"Uploading image {image_disk_name} to Glance.")
+    with open(image_file_name, "rb") as image_data:
+        new_image = image_connection.create_image(name=image_prefix_name,
+                                                  disk_format=disk_format,
+                                                  container_format="bare",
+                                                  visibility="private",
+                                                  data=image_data,
+                                                  **manifest_data)
+    logging.debug(f"Uploaded image {new_image.name}.")
+    return new_image
+
+
+def get_image_build_timestamp(image):
+    build_timestamp = image.properties.get("build-timestamp")
+    if build_timestamp is None:
+        error = f"Unable to find build-timestamp on image {image.id}, " + \
+                "using the current date instead."
+        logging.error(error)
+        return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    return datetime.datetime.strptime(build_timestamp, "%Y-%m-%d %H:%M:%S.%f")
+
+
+def archive_image(image):
+    logging.debug(f"Renaming existing image {image.name}.")
+    archive_date = get_image_build_timestamp(image)
+    image_connection.image.update_image(
+        image.id,
+        name=f"{image.name}_{archive_date}"
+    )
+
+    archived_name = f"{image.name}_{archive_date}"
+    logging.debug(f"Renamed image {image.name} to {archived_name}.")
+
+
+def promote_image(image_connection, image_name, image_disk_name, new_image):
+    build_timestamp = get_image_build_timestamp(new_image)
+    existing_images = list(
+        image_connection.image.images(
+            name=image_disk_name,
+            visibility="public"
+        )
+    )
+    logging.debug(f"Promoting image {image_disk_name}.")
+    if len(existing_images) == 0:
+        image_connection.image.update_image(new_image.id,
+                                            name=image_disk_name,
+                                            visibility="public")
+        logging.info(f"Image {image_name} updated to {new_image.id} : " +
+                     f"{build_timestamp}")
+    elif len(existing_images) == 1:
+        archive_image(existing_images[0])
+        image_connection.image.update_image(new_image.id,
+                                            name=image_disk_name,
+                                            visibility="public")
+        old_image_id = existing_images[0].id
+        old_build_timestamp = get_image_build_timestamp(existing_images[0])
+        logging.info(f"Image {image_name} updated to {new_image.id} : " +
+                     f"{build_timestamp} from {old_image_id}:" +
+                     f"{old_build_timestamp}")
+    else:
+        # we could make this a consistency check that is run upfront so we
+        # don't bother with the rest of this process if something is in this
+        # state
+        error = "There should never be more than 1 public image with the " + \
+                f"same name: {image_disk_name}! Manual intervention required."
+        logging.error(error)
+
+
+
+
+def get_manifest_data(manifest_url):
+    response = requests.get(manifest_url)
+    if response.status_code != 200:
+        raise Exception(f"Error downloading object {manifest_url}: {response.content}")
+    return response.json()
+
+
+def sync_image(storage_url,
+               image_connection,
+               image,
+               current=None,
+               image_prefix="_testing",
+               image_type="qcow2",
+               dry_run=False):
+    # TODO: move dry run to more of the steps
+    if dry_run:
+        logging.info(f"DRY RUN: Syncing image {image.name}.")
+    else:
+        logging.info(f"Syncing image {image.name}.")
+        logging.debug(f"Downloading image {image.name} from {image.container_path}.")
+        manifest_url = f"{storage_url}/{image.container_path}/{image.manifest_name}"
+        manifest_data = get_manifest_data(manifest_url)
+        manifest_data["current"] = current
+        logging.debug(f"Downloaded {image.name} manifest: {manifest_data}, downloading image file.")
+
+        try:
+            temp_file = download_object_to_file(
+                storage_url,
+                image.container_path,
+                image.disk_name
+            )
+
+            glance_image = upload_image_to_glance(
+                image_connection,
+                image_prefix,
+                image.disk_name,
+                temp_file.name,
+                image_type,
+                manifest_data
+            )
+
+            try:
+                temp_file.close()
+            except Exception as delete_error:
+                logging.error(f"Error deleting temporary file: {delete_error}. Manual cleanup required.")
+
+            promote_image(image_connection, image.name, image.disk_name, glance_image)
+
+        except Exception as e:
+            logging.error(f"Error syncing image {image.disk_name}: {e}. Manual intervention required.")
+
+
+def do_sync(storage_url,
+            image_connection,
+            available_images,
+            site_images,
+            current_values={},
+            image_prefix="testing_",
+            image_type="qcow2",
+            dry_run=False):
+
+
+    images_to_sync = []
+    for available_image in available_images:
+        current = current_values[available_image.name]
+        if should_sync_image(available_image.disk_name, site_images, current):
+            images_to_sync.append(available_image)
+
+    num_available_images = len(available_images)
+    num_images_to_sync = len(images_to_sync)
+    num_images_to_skip = num_available_images - num_images_to_sync
+    logging.info(f"Found {num_available_images} available images. " +
+                 f"Already have {num_images_to_skip} images. " +
+                 "Syncing {num_images_to_sync} images: {images_to_sync}".format(
+                     num_images_to_sync=num_images_to_sync,
+                     images_to_sync=[str(i) for i in images_to_sync]))
+
+    for image_to_sync in images_to_sync:
+        sync_image(
+            storage_url,
+            image_connection,
+            image_to_sync,
+            current=current_values[image_to_sync.name],
+            image_prefix=image_prefix,
+            image_type=image_type,
+            dry_run=dry_run
+        )
+    logging.info("Sync complete.")
+
+
+def parse_args(args: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Deploy images to the site.")
+
+    parser.add_argument("--site-yaml", type=str, required=True,
+                        help="A yaml file with site information for syncing.")
+    parser.add_argument("--supports-yaml", type=str,
+                        default="/etc/chameleon_image_tools/supports.yaml",
+                        help="A yaml file with supported images.")
+    parser.add_argument("--dry-run",
+                        action="store_true",
+                        help="Perform a dry run without making any changes.")
+    parser.add_argument("--debug", action="store_true",
+                        help="Enable debug logging")
+    # TODO(pdmars): add a force sync flag that overrides the current check
+
+    return parser.parse_args(args)
+
+
+def main(arg_list: list[str]) -> None:
+    args = parse_args(arg_list)
+
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=log_level)
+
+    if args.dry_run:
+        logging.info("Dry run mode enabled. No changes will be made.")
+
+    # TODO: add this stuff in?
+    # loop over supported_distros to figure out release and variant
+    #with open(args.supports_yaml, 'r') as f:
+    #    supports = yaml.safe_load(f)
+
+    with open(args.site_yaml, "r") as f:
+        site = yaml.safe_load(f)
+
+    base_container = site.get("image_container", "chameleon-supported-images")
+    scope = site.get("scope", "prod")
+    image_type = site.get("image_type", "qcow2")
+    image_prefix = site.get("image_prefix", "testing_")
+    image_store_cloud = site.get("image_store_cloud", "uc_dev")
+    storage_url = site.get("object_store_url")
+    if storage_url is None:
+        raise Exception("The object_store_url is required in your site.yaml config!")
+
+    logging.debug(f"Using base image container/scope: {base_container}/{scope}")
+    image_connection = get_openstack_connection(image_store_cloud)
+
+    current_values = get_current_value(storage_url, base_container, scope)
+    logging.debug(f"Using latest image release: {current_values}")
+
+    # TODO(pdmars): first pass we assume we will release all images, add filters
+    # for different sites later that may not need all images
+    available_images = get_available_images(storage_url,
+                                            base_container,
+                                            scope,
+                                            current_values,
+                                            image_type)
+
+    logging.debug("Available Central Images: {}".format(
+        [str(i) for i in available_images])
+    )
+
+    site_images = get_site_images(image_connection)
+    logging.debug(f"Site Images: {site_images}")
+
+    do_sync(
+        storage_url,
+        image_connection,
+        available_images,
+        site_images,
+        current_values=current_values,
+        image_prefix=image_prefix,
+        image_type=image_type,
+        dry_run=args.dry_run
+    )
+
+
+def launch_main():
+    main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    launch_main()

--- a/src/hammers/image_deployer.py
+++ b/src/hammers/image_deployer.py
@@ -173,7 +173,7 @@ def promote_image(image_connection, image_name, image_disk_name, new_image):
         image_connection.image.update_image(new_image.id,
                                             name=image_disk_name,
                                             visibility="public")
-        logging.info(f"Image {image_name} updated to {new_image.id} : " +
+        logging.info(f"Image {image_name} updated to {new_image.id}: " +
                      f"{build_timestamp}")
     elif len(existing_images) == 1:
         archive_image(image_connection, existing_images[0])
@@ -182,7 +182,7 @@ def promote_image(image_connection, image_name, image_disk_name, new_image):
                                             visibility="public")
         old_image_id = existing_images[0].id
         old_build_timestamp = get_image_build_timestamp(existing_images[0])
-        logging.info(f"Image {image_name} updated to {new_image.id} : " +
+        logging.info(f"Image {image_name} updated to {new_image.id}: " +
                      f"{build_timestamp} from {old_image_id}:" +
                      f"{old_build_timestamp}")
     else:

--- a/src/hammers/image_deployer.py
+++ b/src/hammers/image_deployer.py
@@ -148,7 +148,7 @@ def get_image_build_timestamp(image):
     return datetime.datetime.strptime(build_timestamp, "%Y-%m-%d %H:%M:%S.%f")
 
 
-def archive_image(image):
+def archive_image(image_connection, image):
     logging.debug(f"Renaming existing image {image.name}.")
     archive_date = get_image_build_timestamp(image)
     image_connection.image.update_image(
@@ -176,7 +176,7 @@ def promote_image(image_connection, image_name, image_disk_name, new_image):
         logging.info(f"Image {image_name} updated to {new_image.id} : " +
                      f"{build_timestamp}")
     elif len(existing_images) == 1:
-        archive_image(existing_images[0])
+        archive_image(image_connection, existing_images[0])
         image_connection.image.update_image(new_image.id,
                                             name=image_disk_name,
                                             visibility="public")

--- a/src/hammers/image_deployer.py
+++ b/src/hammers/image_deployer.py
@@ -62,8 +62,10 @@ def get_available_images(
         logging.debug(f"Current objects: {current_objects}")
         for object in islice(current_objects, 1, None):
             object_name = object.split("/")[-1]
+            logging.debug(f"Checking object: {object_name}")
             if object_name.endswith(image_name + ".manifest"):
-                name = object_name.rstrip(".manifest")
+                name = object_name[:-len(".manifest")]
+                logging.debug(f"Found image name: {name}")
                 available_images.append(
                     Image(name,
                           image_type,
@@ -72,6 +74,7 @@ def get_available_images(
                           current_path)
                 )
 
+    logging.debug(f"Found available images: {available_images}")
     return available_images
 
 
@@ -86,7 +89,7 @@ def get_site_images(connection):
     return images
 
 
-def should_sync_image(image_disk_name, site_images, current):
+def should_sync_image(image_connection, image_disk_name, site_images, current):
     if image_disk_name in site_images:
         logging.debug(f"Image {image_disk_name} already in site images.")
         image = image_connection.image.find_image(image_disk_name)
@@ -258,7 +261,7 @@ def do_sync(storage_url,
     images_to_sync = []
     for available_image in available_images:
         current = current_values[available_image.name]
-        if should_sync_image(available_image.disk_name, site_images, current):
+        if should_sync_image(image_connection, available_image.disk_name, site_images, current):
             images_to_sync.append(available_image)
 
     num_available_images = len(available_images)


### PR DESCRIPTION
Main changes here:

- moved image_deployer.py and its config from abracadabra to this repo
- added necessary dependencies for it to the hammers setup
- refactored docs into a docs/ directory with their own pages as we add more tools
- various fixes for the image_deployer.py script + tested it by deploying all images to uc_dev