### PR TITLE
WIP for scheduler framework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
+  "apscheduler",
   "reference_transmogrifier @ git+https://github.com/ChameleonCloud/doni-referenceapi",
   "openstacksdk @ git+https://github.com/ChameleonCloud/openstacksdk@chameleoncloud/blazar",
   "oslo.config",
@@ -48,3 +49,4 @@ image_deployer = "hammers.image_deployer:launch_main"
 set_image_property = "hammers.set_image_property:launch_main"
 generate_reference_repo = "reference_transmogrifier.main:main"
 instance_shelver = "hammers.instance_shelver:main"
+scheduler = "hammers.scheduler:scheduler"

--- a/src/hammers/scheduler.py
+++ b/src/hammers/scheduler.py
@@ -1,0 +1,57 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from hammers import network_ip_cleaner
+import logging
+import time
+
+
+class IpCleanerJob(object):
+    cloud = "envvars"
+
+    default_arg_list = [
+        "--dry-run",
+        "--clean-networks",
+        "--clean-floatingips",
+        "--clean-routers",
+    ]
+    ip_cleaner_args = []
+
+    trigger = None
+    jobid = None
+    name = None
+
+    def __init__(self, cloud: str, jobid, name) -> None:
+        self.cloud = cloud
+        self.trigger = IntervalTrigger(minutes=1, jitter=15)
+        self.jobid = jobid
+        self.name = name
+
+        self.ip_cleaner_args = ["--cloud", self.cloud]
+        self.ip_cleaner_args.extend(self.default_arg_list)
+
+    def get_jobargs(self):
+        return {
+            "id": self.jobid,
+            "name": self.name,
+            "func": network_ip_cleaner.main,
+            "kwargs": {"arg_list": self.ip_cleaner_args},
+            "trigger": self.trigger,
+        }
+
+
+def scheduler():
+    # start with memoryjobstore named default
+    # and threadpoolexecutor named default with count=10
+    scheduler = BackgroundScheduler()
+
+    # start it up
+    scheduler.start()
+
+    ip_cleaner = IpCleanerJob(cloud="envvars", jobid="ip_cleaner", name="ip_cleaner")
+
+    scheduler.add_job(**ip_cleaner.get_jobargs())
+
+    # Keep running
+    logging.info("Scheduler running. Press Ctrl+C to exit.")
+    while True:
+        time.sleep(60)


### PR DESCRIPTION
in order to move away from the complexity of N systemd units+timers, this begins an approach where we configure a single scheduler service, and in its config file, configure what hammers should run and when.

This will ultimately allow us to run a single, persistent container, log results to a single place, and expose relevant metrics.

TODO:

1. parse a config file instead of hard-coding arguments
2. from that config file, dynamically load list of hammers to execute
3. configure persistent job store, sqlite is probably easiest
4. add health check endpoint for the scheduler
5. add basic metrics for each configured hammer
6. update alerting to reference these metrics